### PR TITLE
Fixes Issue #8 Hardware 'Enter' key repeats most recent mouse input 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -164,34 +164,29 @@ function App() {
 
   const updateCellStatuses = (word, rowNumber) => {
     setCellStatuses((prev) => {
-      let ans = answer
-      let wor = word
       const newCellStatuses = [...prev]
       newCellStatuses[rowNumber] = [...prev[rowNumber]]
-      const wordLength = wor.length
+      const wordLength = word.length
+      const answerLetters = answer.split("");
+
+      // set all to gray
+      for (let i = 0; i < wordLength; i++) {
+        newCellStatuses[rowNumber][i] = status.gray
+      }
 
       // check greens
-      for (let i = 0; i < wordLength; i++) {
-        if (wor[i] === ans[i]) {
+      for (let i = wordLength - 1; i >= 0; i--) {
+        if (word[i] === answer[i]) {
           newCellStatuses[rowNumber][i] = status.green
-          ans = ans.substr(0, i) + '.' + ans.substr(i + 1)
-          wor = wor.substr(0, i) + '.' + wor.substr(i + 1)
+          answerLetters.splice(i, 1)
         }
       }
 
       // check yellows
       for (let i = 0; i < wordLength; i++) {
-        if (wor[i] === '.') continue
-
-        if (ans.includes(wor[i])) {
+        if (answerLetters.includes(word[i]) && newCellStatuses[rowNumber][i] !== status.green) {
           newCellStatuses[rowNumber][i] = status.yellow
-        }
-      }
-
-      // set rest to gray
-      for (let i = 0; i < wordLength; i++) {
-        if (newCellStatuses[rowNumber][i] === status.unguessed) {
-          newCellStatuses[rowNumber][i] = status.gray
+          answerLetters.splice(answerLetters.indexOf(word[i]), 1)
         }
       }
 

--- a/src/Keyboard.js
+++ b/src/Keyboard.js
@@ -34,6 +34,7 @@ const Keyboard = ({ letterStatuses, addLetter, onEnterPress, onDeletePress, game
         addLetter(letter)
       } else if (letter === 'ENTER') {
         onEnterPress()
+        event.preventDefault()
       } else if (letter === 'BACKSPACE') {
         onDeletePress()
       }

--- a/src/Keyboard.js
+++ b/src/Keyboard.js
@@ -48,7 +48,7 @@ const Keyboard = ({ letterStatuses, addLetter, onEnterPress, onDeletePress, game
   }, [handleKeyDown])
 
   return (
-    <div className="w-full flex flex-col items-center mb-3">
+    <div className="w-full flex flex-col items-center mb-3 select-none">
       {keyboardLetters.map((row, idx) => (
         <div key={idx} className="w-full flex justify-center my-[5px]">
           {idx === 2 && (


### PR DESCRIPTION
Fixes issue #8  
When enter is pressed, calls 'preventDefault()' on the event to stop the browser from also activating whichever UI elemnt currently has the focus. (Note, it remains possible to activate the focused element using the space key as an alternative).